### PR TITLE
Fixes #32: Do not declare remote URL when creating the datastore

### DIFF
--- a/Classes/common/CDTIncrementalStore.h
+++ b/Classes/common/CDTIncrementalStore.h
@@ -25,14 +25,6 @@ extern NSString *const CDTISException;
 + (NSString *)type;
 
 /**
- *  Returns URL to the local directory that the incremental databases shall be
- *  stored.
- *
- *  @return NSURL
- */
-+ (NSURL *)localDir;
-
-/**
  *  Returns an array of @ref CDTIncrementalStore objects associated with a
  *  @ref NSPersistentStoreCoordinator
  *

--- a/Tests/Tests/IncrementalStore.m
+++ b/Tests/Tests/IncrementalStore.m
@@ -17,6 +17,8 @@
  */
 static BOOL CDTISSupportBatchUpdates = YES;
 
+static NSString *CDTISDBString = @"cdtis_test";
+
 /*
  *  ##Start Ripoff:
  *  The following code segment, that creates a managed object model
@@ -187,6 +189,7 @@ Entry *MakeEntry(NSManagedObjectContext *moc)
 @property (nonatomic, strong) NSManagedObjectModel *managedObjectModel;
 @property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
 @property (nonatomic, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@property (nonatomic, strong) NSURL *storeURL;
 
 @end
 
@@ -243,28 +246,27 @@ static void *ISContextProgress = &ISContextProgress;
         [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
 
     NSError *err = nil;
-    NSPersistentStore *theStore;
-
+    NSURL *docDir = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                            inDomains:NSUserDomainMask] lastObject];
+    NSURL *storeURL = [docDir URLByAppendingPathComponent:CDTISDBString];
     NSString *storeType;
-    NSURL *storeURL;
 
     if (sql) {
         storeType = NSSQLiteStoreType;
-        NSURL *docDir =
-            [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
-                                                    inDomains:NSUserDomainMask] lastObject];
-        storeURL = [docDir URLByAppendingPathComponent:@"cdtis_test.sqlite"];
+        storeURL = [self.storeURL URLByAppendingPathExtension:@"sqlite"];
     } else {
         storeType = [CDTIncrementalStore type];
-        storeURL = [NSURL URLWithString:@"cdtis_test"];
     }
 
-    theStore = [_persistentStoreCoordinator addPersistentStoreWithType:storeType
-                                                         configuration:nil
-                                                                   URL:storeURL
-                                                               options:nil
-                                                                 error:&err];
+    NSPersistentStore *theStore = [_persistentStoreCoordinator addPersistentStoreWithType:storeType
+                                                                            configuration:nil
+                                                                                      URL:storeURL
+                                                                                  options:nil
+                                                                                    error:&err];
     XCTAssertNotNil(theStore, @"could not get theStore: %@", err);
+
+    self.storeURL = storeURL;
+
     return _persistentStoreCoordinator;
 }
 
@@ -279,21 +281,9 @@ static void *ISContextProgress = &ISContextProgress;
         initialized = YES;
     }
 
+    NSError *err;
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSURL *storeURL;
-
-    if (sql) {
-        NSURL *docDir =
-            [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
-                                                    inDomains:NSUserDomainMask] lastObject];
-        storeURL = [docDir URLByAppendingPathComponent:@"cdtis_test.sqlite"];
-    } else {
-        // remove the entire database directory
-        storeURL = [CDTIncrementalStore localDir];
-    }
-
-    NSError *err = nil;
-    if (![fm removeItemAtURL:storeURL error:&err]) {
+    if (![fm removeItemAtURL:self.storeURL error:&err]) {
         if (err.code != NSFileNoSuchFileError) {
             XCTAssertNil(err, @"%@", err);
         }
@@ -1007,7 +997,7 @@ static void *ISContextProgress = &ISContextProgress;
     NSManagedObjectContext *moc = self.managedObjectContext;
     XCTAssertNotNil(moc, @"could not create Context");
 
-    moc.stalenessInterval = 0; // no staleness acceptable
+    moc.stalenessInterval = 0;  // no staleness acceptable
 
     NSDate *now = [NSDate date];
 
@@ -1224,8 +1214,8 @@ static void *ISContextProgress = &ISContextProgress;
                       @"Failed to retain decimal max");
         XCTAssertTrue([minNums.fpDecimal isEqual:[NSDecimalNumber minimumDecimalNumber]],
                       @"Failed to retain decimal min");
-        XCTAssertTrue(
-                      [infNums.fpDecimal isEqual:(NSDecimalNumber *)[NSDecimalNumber numberWithDouble:INFINITY]],
+        XCTAssertTrue([infNums.fpDecimal
+                          isEqual:(NSDecimalNumber *)[NSDecimalNumber numberWithDouble:INFINITY]],
                       @"Failed to retain decimal infinity");
     }
 

--- a/doc/coredata.md
+++ b/doc/coredata.md
@@ -46,7 +46,10 @@ following manner, using `+type` static method to identify the correct
 store type:
 
 ```objc
-NSURL *storeURL = [NSURL URLWithString:databaseURI];
+NSFileManager *fileManager = [NSFileManager defaultManager];
+NSURL *docDir = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+NSString *databaseName = <* String that is the database name *>;
+NSURL *storeURL = [docDir URLByAppendingPathComponent:databaseName];
 NSString *myType = [CDTIncrementalStore type];
 NSPersistentStoreCoordinator *psc = ...
 [psc addPersistentStoreWithType:myType
@@ -56,13 +59,8 @@ NSPersistentStoreCoordinator *psc = ...
                           error:&error])];
 ```
 
-The last component of `databaseURI` should be the name of your
-database. If `databaseURI` has a host component, then that URL will be
-used to specify the remote database where push, pull and sync
-operations will target.
-
-> ***Note***: the remote database details can be defined later in your
-> code.
+> ***Note***: It is the responsibility of the caller to make sure that
+> the path to `docDir` exists.
 
 At this point you can use [Core Data] normally and your changes will
 be saved in the local `CDTDatastore` image.
@@ -82,6 +80,19 @@ is only one `CDTIncrementalStore` object then this is simply:
 NSArray *stores = [CDTIncrementalStore storesFromCoordinator:psc];
 // We know there is only one
 CDTIncrementalStore *myIS = [stores firstObject];
+```
+
+If there is more than one `CDTIncrementalStore` in `stores` then you
+can iterate over stores and compare the URL property.  Example:
+
+```objc
+CDTIncrementalStore *myIS;
+for (CDTIncrementalStore *mis in stores) {
+    if ([storeURL isEqual:mis.URL]) {
+        myIS = mis;
+        break;
+    }
+}
 ```
 
 ### Replication


### PR DESCRIPTION
Fixes #32 

We used to pass in a remote URL to associate the local database with
_and_ put all databases in a magic directory.  This no longer makes
sense since the local datastore can be, and is typically, replicated
against arbitrary remote stores.

This patch makes it more in line with the Core Data model where a file
systems URL is given.  That URL identify a directory where all
datastore files are kept.  It is now the responsibility of the user to
make sure that all but the last path component exists in the system.

Signed-off-by: Jimi Xenidis jimix@pobox.com
